### PR TITLE
Improve WASM source switching and add refresh capability

### DIFF
--- a/src/lib/wasmInterface.ts
+++ b/src/lib/wasmInterface.ts
@@ -114,6 +114,12 @@ export class WasmTypeInference {
     return { ...this.wasmSource };
   }
 
+  async refresh(): Promise<boolean> {
+    this.wasmModule = null;
+    this.isInitialized = false;
+    return await this.initialize();
+  }
+
   async initialize(): Promise<boolean> {
     if (this.isInitialized) return true;
     


### PR DESCRIPTION
## Summary
- add refresh() helper in WASM interface to re-fetch current module
- fire wasmUrlChanged event on load to avoid fallback to default source
- expose manual refresh control in settings modal

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build`


------